### PR TITLE
Topic/dogstatsd support

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -5,7 +5,8 @@
                     array(
                         'serv1' => array('address' => 'udp://200.22.143.12'),
                         'serv2' => array('port' => 8125, 'address' => 'udp://200.22.143.12')
-                    )
+                    ),
+                    new \M6Web\Component\Statsd\MessageFormatter\InfluxDBStatsDMessageFormatter()
                 );
 
 $client->increment('a.graphite.node');

--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -38,7 +38,7 @@ class Client
     private $serverKeys = array();
 
     /**
-     * @var $messageFormatter
+     * @var MessageFormatterInterface
      */
     private $messageFormatter;
 

--- a/src/M6Web/Component/Statsd/MessageEntity.php
+++ b/src/M6Web/Component/Statsd/MessageEntity.php
@@ -88,7 +88,7 @@ class MessageEntity
      *
      * @return bool
      */
-    protected function useSampleRate()
+    public function useSampleRate()
     {
         if (($this->getSampleRate() < 1) && (mt_rand() / mt_getrandmax()) <= $this->getSampleRate()) {
             return true;
@@ -130,6 +130,14 @@ class MessageEntity
     }
 
     /**
+     * @return array
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
      * @return string Tags formatted for sending
      * ex: "server=5,country=fr"
      */
@@ -159,9 +167,22 @@ class MessageEntity
      * format a statsd message
      *
      * @return string
+     *
+     * @deprecated
      */
     public function getStatsdMessage()
     {
+        trigger_error(
+            sprintf(
+                '%s is deprecated and will be removed in the next major version. ' .
+                'Update your code to use %s::%s.',
+                __METHOD__,
+                'M6Web\Component\Statsd\MessageFormatter\MessageFormatterInterface',
+                'format'
+            ),
+            E_USER_DEPRECATED
+        );
+
         $message = sprintf('%s:%s|%s', $this->getFullNode(), $this->getValue(), $this->getUnit());
         if ($this->useSampleRate()) {
             $message .= sprintf('|@%s', $this->getSampleRate());

--- a/src/M6Web/Component/Statsd/MessageFormatter/DogStatsDMessageFormatter.php
+++ b/src/M6Web/Component/Statsd/MessageFormatter/DogStatsDMessageFormatter.php
@@ -1,0 +1,43 @@
+<?php
+namespace M6Web\Component\Statsd\MessageFormatter;
+
+use M6Web\Component\Statsd\MessageEntity;
+
+/**
+ * Formats a StatsD message using the DogStatsD style:
+ * https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#tagging
+ */
+class DogStatsDMessageFormatter implements MessageFormatterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function format(MessageEntity $message)
+    {
+        $formatted = sprintf('%s:%s|%s', $message->getNode(), $message->getValue(), $message->getUnit());
+
+        if ($message->useSampleRate()) {
+            $formatted .= sprintf('|@%s', $message->getSampleRate());
+        }
+
+        if ($message->getTags()) {
+            $formatted .= '|#' . $this->getTagsAsString($message);
+        }
+
+        return $formatted . "\n";
+    }
+
+    /**
+     * @param MessageEntity $message
+     *
+     * @return string
+     */
+    private function getTagsAsString(MessageEntity $message)
+    {
+        $tags = array_map(static function($k, $v) {
+            return $k . ':' . $v;
+        }, array_keys($message->getTags()), $message->getTags());
+
+        return implode(',', $tags);
+    }
+}

--- a/src/M6Web/Component/Statsd/MessageFormatter/InfluxDBStatsDMessageFormatter.php
+++ b/src/M6Web/Component/Statsd/MessageFormatter/InfluxDBStatsDMessageFormatter.php
@@ -1,0 +1,45 @@
+<?php
+namespace M6Web\Component\Statsd\MessageFormatter;
+
+use M6Web\Component\Statsd\MessageEntity;
+
+/**
+ * Formats a StatsD message using the InfluxDB StatsD style:
+ * https://www.influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/#introducing-influx-statsd
+ */
+class InfluxDBStatsDMessageFormatter implements MessageFormatterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function format(MessageEntity $message)
+    {
+        $node = $message->getNode();
+
+        if ($message->getTags()) {
+            $node .= ',' . $this->getTagsAsString($message);
+        }
+
+        $formatted = sprintf('%s:%s|%s', $node, $message->getValue(), $message->getUnit());
+
+        if ($message->useSampleRate()) {
+            $formatted .= sprintf('|@%s', $message->getSampleRate());
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @param MessageEntity $message
+     *
+     * @return string
+     */
+    private function getTagsAsString(MessageEntity $message)
+    {
+        $tags = array_map(static function($k, $v) {
+            return $k . '=' . $v;
+        }, array_keys($message->getTags()), $message->getTags());
+
+        return implode(',', $tags);
+    }
+}

--- a/src/M6Web/Component/Statsd/MessageFormatter/MessageFormatterInterface.php
+++ b/src/M6Web/Component/Statsd/MessageFormatter/MessageFormatterInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace M6Web\Component\Statsd\MessageFormatter;
+
+use M6Web\Component\Statsd\MessageEntity;
+
+/**
+ * Interface for formatting StatsD messages for different StatsD server implementations.
+ */
+interface MessageFormatterInterface
+{
+    /**
+     * @param MessageEntity $message
+     *
+     * @return string
+     */
+    public function format(MessageEntity $message);
+}

--- a/src/M6Web/Component/Tests/Units/Client.php
+++ b/src/M6Web/Component/Tests/Units/Client.php
@@ -313,7 +313,9 @@ class Client extends atoum\test
             ->boolean($client->send())
             ->isEqualTo(true)
             ->mock($client)
-                ->call('writeDatas')->exactly(1);
+                ->call('writeDatas')
+                    ->withArguments('serv2', ['service.foo:1|c'])->once()
+                    ->withAnyArguments()->exactly(1);
         $client = new \mock\M6Web\Component\Statsd\Client($this->getConf());
         $client->getMockController()->writeDatas = function ($server, $datas) {
 
@@ -323,7 +325,9 @@ class Client extends atoum\test
             ->then()
             ->boolean($client->send())
             ->mock($client)
-                ->call('writeDatas')->exactly(1); // but one call
+                ->call('writeDatas')
+                    ->withArguments('serv2', ['service.foo:1|c', 'service.foo:1|c'])->once()
+                    ->withAnyArguments()->exactly(1); // but one call
         $client = new \mock\M6Web\Component\Statsd\Client($this->getConf());
         $client->getMockController()->writeDatas = function ($server, $datas) {
 
@@ -333,12 +337,19 @@ class Client extends atoum\test
             ->then()
             ->boolean($client->send())
             ->mock($client)
-                ->call('writeDatas')->exactly(2);
+                ->call('writeDatas')
+                    ->withArguments('serv1', ['foo2:1|c'])->once()
+                    ->withArguments('serv2', ['foo:1|c'])->once()
+                    ->withAnyArguments()->exactly(2);
 
         $this->if($client->count('foocount', 5))
             ->then()
             ->boolean($client->send())
             ->mock($client)
-                ->call('writeDatas')->exactly(3);
+                ->call('writeDatas')
+                    ->withArguments('serv1', ['foo2:1|c'])->once()
+                    ->withArguments('serv2', ['foo:1|c'])->once()
+                    ->withArguments('serv2', ['foocount:5|c'])->once()
+                    ->withAnyArguments()->exactly(3);
     }
 }

--- a/src/M6Web/Component/Tests/Units/MessageEntity.php
+++ b/src/M6Web/Component/Tests/Units/MessageEntity.php
@@ -38,32 +38,56 @@ class MessageEntity extends atoum\test
      */
     public function testgetStatsdMessage()
     {
+        $expectedDeprecation =
+            'M6Web\Component\Statsd\MessageEntity::getStatsdMessage is deprecated and will be ' .
+            'removed in the next major version. Update your code to use ' .
+            'M6Web\Component\Statsd\MessageFormatter\MessageFormatterInterface::format.';
+
         // not sampled message
-        $this->if($messageEntity = new Statsd\MessageEntity(
-            'raoul.node', 1, 'c'))
-            ->then()
-                ->string($messageEntity->getStatsdMessage())
-                ->isEqualTo('raoul.node:1|c')
-        ;
+        $this
+            ->when(function() {
+                $this->if($messageEntity = new Statsd\MessageEntity(
+                    'raoul.node', 1, 'c'))
+                    ->then()
+                    ->string($messageEntity->getStatsdMessage())
+                    ->isEqualTo('raoul.node:1|c')
+                ;
+            })
+            ->error()
+            ->withMessage($expectedDeprecation)
+            ->exists();
 
         // sampled message
         $this->function->mt_rand = function() { return 1;};
         $this->function->mt_getrandmax = function() { return 10;};
 
-        $this->if($messageEntity = new Statsd\MessageEntity(
-            'raoul.node', 1, 'c', 0.2))
-            ->then()
-                ->string($messageEntity->getStatsdMessage())
-                    ->isEqualTo('raoul.node:1|c|@0.2')
-        ;
+        $this
+            ->when(function() {
+                $this->if($messageEntity = new Statsd\MessageEntity(
+                    'raoul.node', 1, 'c', 0.2))
+                    ->then()
+                        ->string($messageEntity->getStatsdMessage())
+                            ->isEqualTo('raoul.node:1|c|@0.2')
+                ;
+            })
+            ->error()
+            ->withMessage($expectedDeprecation)
+            ->exists();
+
 
         // with tags
-        $this->if($messageEntity = new Statsd\MessageEntity(
-            'raoul.node', 1, 'c', 0.2, ['foo' => 'bar']))
-            ->then()
-            ->string($messageEntity->getStatsdMessage())
-            ->isEqualTo('raoul.node,foo=bar:1|c|@0.2')
-        ;
+        $this
+            ->when(function() {
+                $this->if($messageEntity = new Statsd\MessageEntity(
+                    'raoul.node', 1, 'c', 0.2, ['foo' => 'bar']))
+                    ->then()
+                    ->string($messageEntity->getStatsdMessage())
+                    ->isEqualTo('raoul.node,foo=bar:1|c|@0.2')
+                ;
+            })
+            ->error()
+            ->withMessage($expectedDeprecation)
+            ->exists();
     }
 
     public function testErrorConstructorStatsdMessage()

--- a/src/M6Web/Component/Tests/Units/MessageFormatter/DogStatsDMessageFormatter.php
+++ b/src/M6Web/Component/Tests/Units/MessageFormatter/DogStatsDMessageFormatter.php
@@ -19,9 +19,6 @@ class DogStatsDMessageFormatter extends atoum\test
             ->isEqualTo("raoul.node:1|c\n");
 
         // sampled message
-        $this->function->mt_rand = 1;
-        $this->function->mt_getrandmax = 10;
-
         $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c', 0.2);
         $this->calling($message)->useSampleRate = true;
         $this

--- a/src/M6Web/Component/Tests/Units/MessageFormatter/DogStatsDMessageFormatter.php
+++ b/src/M6Web/Component/Tests/Units/MessageFormatter/DogStatsDMessageFormatter.php
@@ -1,0 +1,42 @@
+<?php
+namespace M6Web\Component\Statsd\Tests\Units\MessageFormatter;
+
+use
+    \M6Web\Component\Statsd,
+    \mageekguy\atoum
+    ;
+
+class DogStatsDMessageFormatter extends atoum\test
+{
+    public function testFormat()
+    {
+        // not sampled message
+        $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c');
+        $this
+            ->if($formatter = new Statsd\MessageFormatter\DogStatsDMessageFormatter())
+            ->then()
+            ->string($formatter->format($message))
+            ->isEqualTo("raoul.node:1|c\n");
+
+        // sampled message
+        $this->function->mt_rand = 1;
+        $this->function->mt_getrandmax = 10;
+
+        $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c', 0.2);
+        $this->calling($message)->useSampleRate = true;
+        $this
+            ->given($formatter = new Statsd\MessageFormatter\DogStatsDMessageFormatter())
+            ->then()
+            ->string($formatter->format($message))
+            ->isEqualTo("raoul.node:1|c|@0.2\n");
+
+        // with tags
+        $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c', 0.2, ['foo' => 'bar']);
+        $this->calling($message)->useSampleRate = true;
+        $this
+            ->if($formatter = new Statsd\MessageFormatter\DogStatsDMessageFormatter())
+            ->then()
+            ->string($formatter->format($message))
+            ->isEqualTo("raoul.node:1|c|@0.2|#foo:bar\n");
+    }
+}

--- a/src/M6Web/Component/Tests/Units/MessageFormatter/InfluxDBStatsDMessageFormatter.php
+++ b/src/M6Web/Component/Tests/Units/MessageFormatter/InfluxDBStatsDMessageFormatter.php
@@ -19,9 +19,6 @@ class InfluxDBStatsDMessageFormatter extends atoum\test
             ->isEqualTo('raoul.node:1|c');
 
         // sampled message
-        $this->function->mt_rand = 1;
-        $this->function->mt_getrandmax = 10;
-
         $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c', 0.2);
         $this->calling($message)->useSampleRate = true;
         $this

--- a/src/M6Web/Component/Tests/Units/MessageFormatter/InfluxDBStatsDMessageFormatter.php
+++ b/src/M6Web/Component/Tests/Units/MessageFormatter/InfluxDBStatsDMessageFormatter.php
@@ -1,0 +1,42 @@
+<?php
+namespace M6Web\Component\Statsd\Tests\Units\MessageFormatter;
+
+use
+    \M6Web\Component\Statsd,
+    \mageekguy\atoum
+    ;
+
+class InfluxDBStatsDMessageFormatter extends atoum\test
+{
+    public function testFormat()
+    {
+        // not sampled message
+        $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c');
+        $this
+            ->if($formatter = new Statsd\MessageFormatter\InfluxDBStatsDMessageFormatter())
+            ->then()
+            ->string($formatter->format($message))
+            ->isEqualTo('raoul.node:1|c');
+
+        // sampled message
+        $this->function->mt_rand = 1;
+        $this->function->mt_getrandmax = 10;
+
+        $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c', 0.2);
+        $this->calling($message)->useSampleRate = true;
+        $this
+            ->given($formatter = new Statsd\MessageFormatter\InfluxDBStatsDMessageFormatter())
+            ->then()
+            ->string($formatter->format($message))
+            ->isEqualTo('raoul.node:1|c|@0.2');
+
+        // with tags
+        $message = new \mock\M6Web\Component\Statsd\MessageEntity('raoul.node', 1, 'c', 0.2, ['foo' => 'bar']);
+        $this->calling($message)->useSampleRate = true;
+        $this
+            ->if($formatter = new Statsd\MessageFormatter\InfluxDBStatsDMessageFormatter())
+            ->then()
+            ->string($formatter->format($message))
+            ->isEqualTo('raoul.node,foo=bar:1|c|@0.2');
+    }
+}


### PR DESCRIPTION
Extracts the logic for formatting the statsd message to an interface and adds an alternative DogStatsD formatter.

I think the current statsd format is InfluxDB StatsD style as per: https://github.com/prometheus/statsd_exporter#tagging-extensions (and some references I can see to InfluxDB in some other issues in this repo).